### PR TITLE
Fix: X-Authenticated-User missing between SBC & FS

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -223,7 +223,7 @@ class CallSession extends Emitter {
       if (this.req.locals.application_sid) {
         Object.assign(headers, {'X-Application-Sid': this.req.locals.application_sid});
       }
-      else if (this.req.authorization) {
+      if (this.req.authorization) {
         if (this.req.authorization.grant && this.req.authorization.grant.application_sid) {
           Object.assign(headers, {'X-Application-Sid': this.req.authorization.grant.application_sid});
         }


### PR DESCRIPTION
When our sip trunk (3cx) makes an outbound call, webhook did not send the `X-Authenticated-User` header in payload. On investigation, SBC did not send the sip header to FS.

(Works in 0.7.9)

It appears that the check for `this.req.locals.application_sid` makes the check for `this.req.authorization` unreachable. 

Removed "else" making the authorization check independent. 

Related Issue: [https://github.com/jambonz/jambonz-feature-server/issues/301](https://github.com/jambonz/jambonz-feature-server/issues/301)