### PR TITLE
Feat/MS Teams CIDR Check

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('jambonz:sbc-inbound');
 const assert = require('assert');
 const parseUri = require('drachtio-srf').parseUri;
-const {nudgeCallCounts, roundTripTime} = require('./utils');
+const {nudgeCallCounts, roundTripTime, isMSTeamsCIDR} = require('./utils');
 const digestChallenge = require('@jambonz/digest-utils');
 const msProxyIps = process.env.MS_TEAMS_SIP_PROXY_IPS ?
   process.env.MS_TEAMS_SIP_PROXY_IPS.split(',').map((i) => i.trim()) :
@@ -155,7 +155,7 @@ module.exports = function(srf, logger) {
           ...req.locals
         };
       }
-      else if (msProxyIps.includes(req.source_address)) {
+      else if (msProxyIps.includes(req.source_address) || isMSTeamsCIDR(req.source_address)) {
         logger.info({source_address: req.source_address}, 'identifyAccount: incoming call from Microsoft Teams');
         const uri = parseUri(req.uri);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,50 +3,50 @@ const srtpCharacteristics = require('../data/srtp-transcoding');
 let idx = 0;
 
 const isWSS = (req) => {
-  return req.getParsedHeader('Via')[0].protocol.toLowerCase().startsWith('ws');
+    return req.getParsedHeader('Via')[0].protocol.toLowerCase().startsWith('ws');
 };
 
 const getAppserver = (srf) => {
-  const len = srf.locals.featureServers.length;
-  return srf.locals.featureServers[ idx++ % len];
+    const len = srf.locals.featureServers.length;
+    return srf.locals.featureServers[idx++ % len];
 };
 
 function makeRtpEngineOpts(req, srcIsUsingSrtp, dstIsUsingSrtp, teams = false) {
-  const rtpCopy = JSON.parse(JSON.stringify(rtpCharacteristics));
-  const srtpCopy = JSON.parse(JSON.stringify(srtpCharacteristics));
-  const from = req.getParsedHeader('from');
-  const srtpOpts = teams ? srtpCopy['teams'] : srtpCopy['default'];
-  const dstOpts = dstIsUsingSrtp ? srtpOpts : rtpCopy;
-  const srcOpts = srcIsUsingSrtp ? srtpOpts : rtpCopy;
+    const rtpCopy = JSON.parse(JSON.stringify(rtpCharacteristics));
+    const srtpCopy = JSON.parse(JSON.stringify(srtpCharacteristics));
+    const from = req.getParsedHeader('from');
+    const srtpOpts = teams ? srtpCopy['teams'] : srtpCopy['default'];
+    const dstOpts = dstIsUsingSrtp ? srtpOpts : rtpCopy;
+    const srcOpts = srcIsUsingSrtp ? srtpOpts : rtpCopy;
 
-  /* webrtc clients (e.g. sipjs) send DMTF via SIP INFO */
-  if ((srcIsUsingSrtp || dstIsUsingSrtp) && !teams) {
-    dstOpts.flags.push('inject DTMF');
-    srcOpts.flags.push('inject DTMF');
-  }
-  const common = {
-    'call-id': req.get('Call-ID'),
-    'replace': ['origin', 'session-connection'],
-    'record call': process.env.JAMBONES_RECORD_ALL_CALLS ? 'yes' : 'no'
-  };
-  return {
-    common,
-    uas: {
-      tag: from.params.tag,
-      mediaOpts: srcOpts
-    },
-    uac: {
-      tag: null,
-      mediaOpts: dstOpts
+    /* webrtc clients (e.g. sipjs) send DMTF via SIP INFO */
+    if ((srcIsUsingSrtp || dstIsUsingSrtp) && !teams) {
+        dstOpts.flags.push('inject DTMF');
+        srcOpts.flags.push('inject DTMF');
     }
-  };
+    const common = {
+        'call-id': req.get('Call-ID'),
+        'replace': ['origin', 'session-connection'],
+        'record call': process.env.JAMBONES_RECORD_ALL_CALLS ? 'yes' : 'no'
+    };
+    return {
+        common,
+        uas: {
+            tag: from.params.tag,
+            mediaOpts: srcOpts
+        },
+        uac: {
+            tag: null,
+            mediaOpts: dstOpts
+        }
+    };
 }
 
 const SdpWantsSDES = (sdp) => {
-  return /m=audio.*\s+RTP\/SAVP/.test(sdp);
+    return /m=audio.*\s+RTP\/SAVP/.test(sdp);
 };
 const SdpWantsSrtp = (sdp) => {
-  return /m=audio.*SAVP/.test(sdp);
+    return /m=audio.*SAVP/.test(sdp);
 };
 
 const makeAccountCallCountKey = (sid) => `incalls:account:${sid}`;
@@ -54,145 +54,183 @@ const makeSPCallCountKey = (sid) => `incalls:sp:${sid}:`;
 const makeAppCallCountKey = (sid) => `incalls:app${sid}:`;
 
 const normalizeDID = (tel) => {
-  const regex = /^\+(\d+)$/;
-  const arr = regex.exec(tel);
-  return arr ? arr[1] : tel;
+    const regex = /^\+(\d+)$/;
+    const arr = regex.exec(tel);
+    return arr ? arr[1] : tel;
 };
 
 const equalsIgnoreOrder = (a, b) => {
-  if (a.length !== b.length) return false;
-  const uniqueValues = new Set([...a, ...b]);
-  for (const v of uniqueValues) {
-    const aCount = a.filter((e) => e === v).length;
-    const bCount = b.filter((e) => e === v).length;
-    if (aCount !== bCount) return false;
-  }
-  return true;
+    if (a.length !== b.length) return false;
+    const uniqueValues = new Set([...a, ...b]);
+    for (const v of uniqueValues) {
+        const aCount = a.filter((e) => e === v).length;
+        const bCount = b.filter((e) => e === v).length;
+        if (aCount !== bCount) return false;
+    }
+    return true;
 };
 
-const  systemHealth = async(redisClient, ping, getCount) => {
-  await Promise.all([redisClient.ping(), ping()]);
-  return getCount();
+const systemHealth = async (redisClient, ping, getCount) => {
+    await Promise.all([redisClient.ping(), ping()]);
+    return getCount();
 };
 
 const doListen = (logger, app, port, resolve) => {
-  return app.listen(port, () => {
-    logger.info(`Health check server listening on http://localhost:${port}`);
-    resolve(app);
-  });
+    return app.listen(port, () => {
+        logger.info(`Health check server listening on http://localhost:${port}`);
+        resolve(app);
+    });
 };
 const handleErrors = (logger, app, resolve, reject, e) => {
-  if (e.code === 'EADDRINUSE' &&
-    process.env.HTTP_PORT_MAX &&
-    e.port < process.env.HTTP_PORT_MAX) {
+    if (e.code === 'EADDRINUSE' &&
+        process.env.HTTP_PORT_MAX &&
+        e.port < process.env.HTTP_PORT_MAX) {
 
-    logger.info(`Health check server failed to bind port on ${e.port}, will try next port`);
-    const server = doListen(logger, app, ++e.port, resolve);
-    server.on('error', handleErrors.bind(null, logger, app, resolve, reject));
-    return;
-  }
-  reject(e);
+        logger.info(`Health check server failed to bind port on ${e.port}, will try next port`);
+        const server = doListen(logger, app, ++e.port, resolve);
+        server.on('error', handleErrors.bind(null, logger, app, resolve, reject));
+        return;
+    }
+    reject(e);
 };
 
 
 const createHealthCheckApp = (port, logger) => {
-  const express = require('express');
-  const app = express();
+    const express = require('express');
+    const app = express();
 
-  app.use(express.urlencoded({ extended: true }));
-  app.use(express.json());
+    app.use(express.urlencoded({extended: true}));
+    app.use(express.json());
 
-  return new Promise((resolve, reject) => {
-    const server = doListen(logger, app, port, resolve);
-    server.on('error', handleErrors.bind(null, logger, app, resolve, reject));
-  });
+    return new Promise((resolve, reject) => {
+        const server = doListen(logger, app, port, resolve);
+        server.on('error', handleErrors.bind(null, logger, app, resolve, reject));
+    });
 };
 
-const nudgeCallCounts = async(logger, sids, nudgeOperator, writers) => {
-  const {service_provider_sid, account_sid, application_sid} = sids;
-  const {writeCallCount, writeCallCountSP, writeCallCountApp} = writers;
-  const nudges = [];
-  const writes = [];
+const nudgeCallCounts = async (logger, sids, nudgeOperator, writers) => {
+    const {service_provider_sid, account_sid, application_sid} = sids;
+    const {writeCallCount, writeCallCountSP, writeCallCountApp} = writers;
+    const nudges = [];
+    const writes = [];
 
-  if (process.env.JAMBONES_TRACK_SP_CALLS) {
-    const key = makeSPCallCountKey(service_provider_sid);
-    nudges.push(nudgeOperator(key));
-  }
-  else {
-    nudges.push(() => Promise.resolve(null));
-  }
-
-  if (process.env.JAMBONES_TRACK_ACCOUNT_CALLS || process.env.JAMBONES_HOSTING) {
-    const key = makeAccountCallCountKey(account_sid);
-    nudges.push(nudgeOperator(key));
-  }
-  else {
-    nudges.push(() => Promise.resolve(null));
-  }
-
-  if (process.env.JAMBONES_TRACK_APP_CALLS && application_sid) {
-    const key = makeAppCallCountKey(application_sid);
-    nudges.push(nudgeOperator(key));
-  }
-  else {
-    nudges.push(() => Promise.resolve(null));
-  }
-
-  try {
-    const [callsSP, calls, callsApp] = await Promise.all(nudges);
-    logger.debug({
-      calls, callsSP, callsApp,
-      service_provider_sid, account_sid, application_sid}, 'call counts after adjustment');
     if (process.env.JAMBONES_TRACK_SP_CALLS) {
-      writes.push(writeCallCountSP({service_provider_sid, calls_in_progress: callsSP}));
+        const key = makeSPCallCountKey(service_provider_sid);
+        nudges.push(nudgeOperator(key));
+    } else {
+        nudges.push(() => Promise.resolve(null));
     }
 
     if (process.env.JAMBONES_TRACK_ACCOUNT_CALLS || process.env.JAMBONES_HOSTING) {
-      writes.push(writeCallCount({service_provider_sid, account_sid, calls_in_progress: calls}));
+        const key = makeAccountCallCountKey(account_sid);
+        nudges.push(nudgeOperator(key));
+    } else {
+        nudges.push(() => Promise.resolve(null));
     }
 
     if (process.env.JAMBONES_TRACK_APP_CALLS && application_sid) {
-      writes.push(writeCallCountApp({service_provider_sid, account_sid, application_sid, calls_in_progress: callsApp}));
+        const key = makeAppCallCountKey(application_sid);
+        nudges.push(nudgeOperator(key));
+    } else {
+        nudges.push(() => Promise.resolve(null));
     }
 
-    /* write the call counts to the database */
-    Promise.all(writes).catch((err) => logger.error({err}, 'Error writing call counts'));
+    try {
+        const [callsSP, calls, callsApp] = await Promise.all(nudges);
+        logger.debug({
+            calls, callsSP, callsApp,
+            service_provider_sid, account_sid, application_sid
+        }, 'call counts after adjustment');
+        if (process.env.JAMBONES_TRACK_SP_CALLS) {
+            writes.push(writeCallCountSP({service_provider_sid, calls_in_progress: callsSP}));
+        }
 
-    return {callsSP, calls, callsApp};
-  } catch (err) {
-    logger.error(err, 'error incrementing call counts');
-  }
+        if (process.env.JAMBONES_TRACK_ACCOUNT_CALLS || process.env.JAMBONES_HOSTING) {
+            writes.push(writeCallCount({service_provider_sid, account_sid, calls_in_progress: calls}));
+        }
 
-  return {callsSP: null, calls: null, callsApp: null};
+        if (process.env.JAMBONES_TRACK_APP_CALLS && application_sid) {
+            writes.push(writeCallCountApp({
+                service_provider_sid,
+                account_sid,
+                application_sid,
+                calls_in_progress: callsApp
+            }));
+        }
+
+        /* write the call counts to the database */
+        Promise.all(writes).catch((err) => logger.error({err}, 'Error writing call counts'));
+
+        return {callsSP, calls, callsApp};
+    } catch (err) {
+        logger.error(err, 'error incrementing call counts');
+    }
+
+    return {callsSP: null, calls: null, callsApp: null};
 };
 
 const roundTripTime = (startAt) => {
-  const diff = process.hrtime(startAt);
-  const time = diff[0] * 1e3 + diff[1] * 1e-6;
-  return time.toFixed(0);
+    const diff = process.hrtime(startAt);
+    const time = diff[0] * 1e3 + diff[1] * 1e-6;
+    return time.toFixed(0);
 };
 
 const parseConnectionIp = (sdp) => {
-  const regex = /c=IN IP4 ([0-9.]+)/;
-  const arr = regex.exec(sdp);
-  return arr ? arr[1] : null;
+    const regex = /c=IN IP4 ([0-9.]+)/;
+    const arr = regex.exec(sdp);
+    return arr ? arr[1] : null;
 };
 
+/**
+ * Converts IPv4 to an int
+ * @param ipv4 IPv4 address, example 172.31.0.1
+ * @returns an int representation of an ipv4 address
+ * */
+const ip4ToInt = ipv4 =>
+    ipv4.split('.').reduce((ipInt, octet) =>
+        (ipInt << 8) + parseInt(octet, 10), 0) >>> 0;
+
+/**
+ * Checks IP against given CIDR
+ * @param ip IPv4 address, example 172.31.0.1
+ * @param cidr Array of IPv4 CIDR notations example ['172.31.0.0/16', '192.168.0.0/24']
+ * @returns true if IP is present in network CIDR
+ * */
+const isIp4InCidr = ip => cidr => {
+    const [range, bits = 32] = cidr.split('/');
+    const mask = ~(2 ** (32 - bits) - 1);
+    return (ip4ToInt(ip) & mask) === (ip4ToInt(range) & mask);
+};
+
+/**
+ * Checks if ip is one of MS Teams sip signalling ips
+ * https://learn.microsoft.com/en-us/azure/communication-services/concepts/telephony/direct-routing-infrastructure#sip-signaling-fqdns
+ * @param ip IP address, example 172.31.0.1
+ * */
+const isMSTeamsCIDR = (ip) => {
+    const cidrs = [
+        '52.112.0.0/14',
+        '52.120.0.0/14'
+    ];
+    return cidrs.some(isIp4InCidr(ip));
+}
 
 module.exports = {
-  isWSS,
-  SdpWantsSrtp,
-  SdpWantsSDES,
-  getAppserver,
-  makeRtpEngineOpts,
-  makeAccountCallCountKey,
-  makeSPCallCountKey,
-  makeAppCallCountKey,
-  normalizeDID,
-  equalsIgnoreOrder,
-  systemHealth,
-  createHealthCheckApp,
-  nudgeCallCounts,
-  roundTripTime,
-  parseConnectionIp
+    isWSS,
+    SdpWantsSrtp,
+    SdpWantsSDES,
+    getAppserver,
+    makeRtpEngineOpts,
+    makeAccountCallCountKey,
+    makeSPCallCountKey,
+    makeAppCallCountKey,
+    normalizeDID,
+    equalsIgnoreOrder,
+    systemHealth,
+    createHealthCheckApp,
+    nudgeCallCounts,
+    roundTripTime,
+    parseConnectionIp,
+    isIp4InCidr,
+    isMSTeamsCIDR
 };


### PR DESCRIPTION
Currently IPs are checked against an environment variable. This has worked up until now but MS are mentioning that new IPs may be introduced as part of a role out of new TLS certificates. This mean we are always behind in trying to whitelist MS Teams IPs.  MS Teams has 2x ip ranges which covers all eventualities.

https://learn.microsoft.com/en-us/azure/communication-services/concepts/telephony/direct-routing-infrastructure#sip-signaling-fqdns

I have added a `isMSTeamsCIDR` method check for MS Teams. Also exported a simple `isIp4InCidr` as thought it could be useful.

The following will need to be added to jambonz/infrastructure and whitelisted on AWS-Security Groups/Firewalls

```
52.112.0.0/14 (IP addresses from 52.112.0.0 to 52.115.255.255)
52.120.0.0/14 (IP addresses from 52.120.0.0 to 52.123.255.255)
```

I have kept the env variable in place in case there are custom IPs that need adding at some point but may be depreciated now?