### PR TITLE
feat/MS Teams IP check improvement

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('jambonz:sbc-inbound');
 const assert = require('assert');
 const parseUri = require('drachtio-srf').parseUri;
-const {nudgeCallCounts, roundTripTime} = require('./utils');
+const {nudgeCallCounts, roundTripTime, isMSTeamsCIDR} = require('./utils');
 const digestChallenge = require('@jambonz/digest-utils');
 const msProxyIps = process.env.MS_TEAMS_SIP_PROXY_IPS ?
   process.env.MS_TEAMS_SIP_PROXY_IPS.split(',').map((i) => i.trim()) :
@@ -155,7 +155,7 @@ module.exports = function(srf, logger) {
           ...req.locals
         };
       }
-      else if (msProxyIps.includes(req.source_address)) {
+      else if (msProxyIps.includes(req.source_address) || isMSTeamsCIDR(req.source_address)) {
         logger.info({source_address: req.source_address}, 'identifyAccount: incoming call from Microsoft Teams');
         const uri = parseUri(req.uri);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const CIDRMatcher = require('cidr-matcher');
+const express = require('express');
 const rtpCharacteristics = require('../data/rtp-transcoding');
 const srtpCharacteristics = require('../data/srtp-transcoding');
 
@@ -98,7 +99,6 @@ const handleErrors = (logger, app, resolve, reject, e) => {
 
 
 const createHealthCheckApp = (port, logger) => {
-  const express = require('express');
   const app = express();
 
   app.use(express.urlencoded({ extended: true }));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const rtpCharacteristics = require('../data/rtp-transcoding');
 const srtpCharacteristics = require('../data/srtp-transcoding');
-const CIDRMatcher = require('cidr-matcher');
+
 let idx = 0;
 
 const isWSS = (req) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const rtpCharacteristics = require('../data/rtp-transcoding');
 const srtpCharacteristics = require('../data/srtp-transcoding');
+const CIDRMatcher = require('cidr-matcher');
 let idx = 0;
 
 const isWSS = (req) => {
@@ -179,38 +180,19 @@ const parseConnectionIp = (sdp) => {
 };
 
 /**
- * Converts IPv4 to an int
- * @param ipv4 IPv4 address, example 172.31.0.1
- * @returns an int representation of an ipv4 address
- * */
-const ip4ToInt = (ipv4) =>
-  ipv4.split('.').reduce((ipInt, octet) =>
-    (ipInt << 8) + parseInt(octet, 10), 0) >>> 0;
-
-/**
- * Checks IP against given CIDR
- * @param ip IPv4 address, example 172.31.0.1
- * @param cidr Array of IPv4 CIDR notations example ['172.31.0.0/16', '192.168.0.0/24']
- * @returns true if IP is present in network CIDR
- * */
-const isIp4InCidr = (ip) => (cidr) => {
-  const [range, bits = 32] = cidr.split('/');
-  const mask = ~(2 ** (32 - bits) - 1);
-  return (ip4ToInt(ip) & mask) === (ip4ToInt(range) & mask);
-};
-
-/**
  * Checks if ip is one of MS Teams sip signalling ips
  * https://learn.microsoft.com/en-us/azure/communication-services/concepts
  * /telephony/direct-routing-infrastructure#sip-signaling-fqdns
  * @param ip IP address, example 172.31.0.1
  * */
 const isMSTeamsCIDR = (ip) => {
+  const CIDRMatcher = require('cidr-matcher');
   const cidrs = [
     '52.112.0.0/14',
     '52.120.0.0/14'
   ];
-  return cidrs.some(isIp4InCidr(ip));
+  const matcher = new CIDRMatcher(cidrs);
+  return matcher.contains(ip);
 };
 
 module.exports = {
@@ -229,6 +211,5 @@ module.exports = {
   nudgeCallCounts,
   roundTripTime,
   parseConnectionIp,
-  isMSTeamsCIDR,
-  isIp4InCidr
+  isMSTeamsCIDR
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+const CIDRMatcher = require('cidr-matcher');
 const rtpCharacteristics = require('../data/rtp-transcoding');
 const srtpCharacteristics = require('../data/srtp-transcoding');
 
@@ -186,7 +187,6 @@ const parseConnectionIp = (sdp) => {
  * @param ip IP address, example 172.31.0.1
  * */
 const isMSTeamsCIDR = (ip) => {
-  const CIDRMatcher = require('cidr-matcher');
   const cidrs = [
     '52.112.0.0/14',
     '52.120.0.0/14'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -178,6 +178,40 @@ const parseConnectionIp = (sdp) => {
   return arr ? arr[1] : null;
 };
 
+/**
+ * Converts IPv4 to an int
+ * @param ipv4 IPv4 address, example 172.31.0.1
+ * @returns an int representation of an ipv4 address
+ * */
+const ip4ToInt = (ipv4) =>
+  ipv4.split('.').reduce((ipInt, octet) =>
+    (ipInt << 8) + parseInt(octet, 10), 0) >>> 0;
+
+/**
+ * Checks IP against given CIDR
+ * @param ip IPv4 address, example 172.31.0.1
+ * @param cidr Array of IPv4 CIDR notations example ['172.31.0.0/16', '192.168.0.0/24']
+ * @returns true if IP is present in network CIDR
+ * */
+const isIp4InCidr = (ip) => (cidr) => {
+  const [range, bits = 32] = cidr.split('/');
+  const mask = ~(2 ** (32 - bits) - 1);
+  return (ip4ToInt(ip) & mask) === (ip4ToInt(range) & mask);
+};
+
+/**
+ * Checks if ip is one of MS Teams sip signalling ips
+ * https://learn.microsoft.com/en-us/azure/communication-services/concepts
+ * /telephony/direct-routing-infrastructure#sip-signaling-fqdns
+ * @param ip IP address, example 172.31.0.1
+ * */
+const isMSTeamsCIDR = (ip) => {
+  const cidrs = [
+    '52.112.0.0/14',
+    '52.120.0.0/14'
+  ];
+  return cidrs.some(isIp4InCidr(ip));
+};
 
 module.exports = {
   isWSS,
@@ -194,5 +228,7 @@ module.exports = {
   createHealthCheckApp,
   nudgeCallCounts,
   roundTripTime,
-  parseConnectionIp
+  parseConnectionIp,
+  isMSTeamsCIDR,
+  isIp4InCidr
 };


### PR DESCRIPTION
Currently IPs are checked against an environment variable. This has worked up until now but MS are mentioning that new IPs may be introduced as part of a role out of new TLS certificates. This mean we are always behind in trying to whitelist MS Teams IPs. MS Teams has 2x ip ranges which covers all eventualities.

[Check here for MS Sip Endpoints](https://learn.microsoft.com/en-us/azure/communication-services/concepts/telephony/direct-routing-infrastructure#sip-signaling-fqdns)

I have added a `isMSTeamsCIDR` method check for MS Teams. Also exported a simple isIp4InCidr as thought it could be useful.

The following will need to be added to `jambonz/infrastructure` and whitelisted on AWS-Security Groups/Firewalls

```
52.112.0.0/14 (IP addresses from 52.112.0.0 to 52.115.255.255)
52.120.0.0/14 (IP addresses from 52.120.0.0 to 52.123.255.255)
```

I have kept the env variable in place in case there are custom IPs that need adding at some point but may be depreciated now?

More information about new TLS root CA [here](https://learn.microsoft.com/en-us/microsoftteams/direct-routing-whats-new)