### PR TITLE
fixed pad_crypto does not work if not a incoming call to a sip realm

### DIFF
--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -293,7 +293,17 @@ module.exports = (srf, logger) => {
       const [gw] = await pp.query(sqlSelectAllGatewaysForSP);
       let matches = gw
         .sort((a, b) => b.netmask - a.netmask)
-        .filter(gatewayMatchesSourceAddress.bind(null, logger, req.source_address));
+        .filter(gatewayMatchesSourceAddress.bind(null, logger, req.source_address))
+        .map((gw) => {
+          return {
+            voip_carrier_sid: gw.voip_carrier_sid,
+            name: gw.name,
+            service_provider_sid: gw.service_provider_sid,
+            account_sid: gw.account_sid,
+            application_sid: gw.application_sid,
+            pad_crypto: gw.pad_crypto
+          };
+        });
       /* remove duplicates, winnow down to voip_carriers, not gateways */
       if (matches.length > 1) {
         matches = [...new Set(matches.map(JSON.stringify))].map(JSON.parse);

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -293,16 +293,7 @@ module.exports = (srf, logger) => {
       const [gw] = await pp.query(sqlSelectAllGatewaysForSP);
       let matches = gw
         .sort((a, b) => b.netmask - a.netmask)
-        .filter(gatewayMatchesSourceAddress.bind(null, logger, req.source_address))
-        .map((gw) => {
-          return {
-            voip_carrier_sid: gw.voip_carrier_sid,
-            name: gw.name,
-            service_provider_sid: gw.service_provider_sid,
-            account_sid: gw.account_sid,
-            application_sid: gw.application_sid
-          };
-        });
+        .filter(gatewayMatchesSourceAddress.bind(null, logger, req.source_address));
       /* remove duplicates, winnow down to voip_carriers, not gateways */
       if (matches.length > 1) {
         matches = [...new Set(matches.map(JSON.stringify))].map(JSON.parse);


### PR DESCRIPTION
Incoming call to non sip realm.
sbc inbound successfully identify the sip gateway by source address and called number from the request.

pad_crypto is cleared by the map method that make call_session later cannot identify if he need to pad_crypto or not