### PR TITLE
fix missing application_sid

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -384,7 +384,7 @@ module.exports = function(srf, logger) {
             carrier: grant.auth_trunk.name,
             gateway: grant.auth_trunk,
             voip_carrier_sid: grant.auth_trunk.voip_carrier_sid,
-            application_sid: application_sid || grant.auth_trunk.application_sid,
+            application_sid: application_sid || grant.auth_trunk.application_sid || req.locals.application_sid,
           };
           // as call from auth carrier, clean req.authorization that impact on legacy logic for authenticated user
           delete req.authorization;


### PR DESCRIPTION
If application_sid is not set from the grant object, use req.locals.application_sid