### PR TITLE
fix error handler middleware parameter order

### DIFF
--- a/app.js
+++ b/app.js
@@ -270,7 +270,7 @@ srf.invite((req, res) => {
   session.connect();
 });
 
-srf.use((req, res, next, err) => {
+srf.use((err, req, res, next) => {
   logger.error(err, 'hit top-level error handler');
   res.send(500);
 });


### PR DESCRIPTION
## Summary
- Fixed the error handler middleware parameter order from `(req, res, next, err)` to `(err, req, res, next)`
- This was causing `res.send is not a function` errors when the top-level error handler was invoked

## Test plan
- Deploy to a test environment
- Trigger an error condition (e.g., webhook returning 5xx error)
- Verify the error handler correctly sends a 500 response instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)